### PR TITLE
& statt &amp; für Anmeldebestätigungslink

### DIFF
--- a/lib/user.php
+++ b/lib/user.php
@@ -262,10 +262,10 @@ class MultinewsletterUser {
         $content = preg_replace('/ {2,}/', ' ', $content);
 
         $subscribe_link = (\rex_addon::get('yrewrite')->isAvailable() ? \rex_yrewrite::getCurrentDomain()->getUrl() : \rex::getServer()) 
-			. trim(trim(rex_getUrl($addon->getConfig('link'), $this->clang_id, ['activationkey' => $this->activationkey, 'email' => rawurldecode($this->email)]), "/"), "./");
+			. trim(trim(rex_getUrl($addon->getConfig('link'), $this->clang_id, ['activationkey' => $this->activationkey, 'email' => rawurldecode($this->email)], '&'), "/"), "./");
         if (rex_addon::get('yrewrite')->isAvailable()) {
             // Use Yrewrite, support for Redaxo installations in subfolders: https://github.com/TobiasKrais/multinewsletter/issues/7
-            $subscribe_link = \rex_yrewrite::getFullUrlByArticleId($addon->getConfig('link'), $this->clang_id, ['activationkey' => $this->activationkey, 'email' => rawurldecode($this->email)]);
+            $subscribe_link = \rex_yrewrite::getFullUrlByArticleId($addon->getConfig('link'), $this->clang_id, ['activationkey' => $this->activationkey, 'email' => rawurldecode($this->email)], '&');
         }
         return str_replace("+++AKTIVIERUNGSLINK+++", $subscribe_link, $content);
     }


### PR DESCRIPTION
Unter r5.7.1 sendet der multinewsletter 3.2.5 den Bestätigungslink mit` &amp;` als Parametertrenner. Wenn ich den Link dann klicke, wird der Aktivierungsschlüssel nicht erkannt.